### PR TITLE
Fix newline in table cell

### DIFF
--- a/notion-md-export.main.kts
+++ b/notion-md-export.main.kts
@@ -368,7 +368,7 @@ fun block2MD(block: TableBlock): String {
                     }
                     val celList = mutableListOf<String>()
                     for (richText in rowBlocks.asTableRow().tableRow.cells) {
-                        celList.add(getRichText(richText))
+                        celList.add(getRichText(richText).replace("  \n", "</br>"))
                     }
                     str += "|${celList.joinToString("|")}|\n"
                 }

--- a/notion-md-export.main.kts
+++ b/notion-md-export.main.kts
@@ -366,11 +366,11 @@ fun block2MD(block: TableBlock): String {
                     if (index == 1) {
                         str += "|"+" --- |".repeat(colNum)+"\n"
                     }
-                    val celList = mutableListOf<String>()
+                    val cellList = mutableListOf<String>()
                     for (richText in rowBlocks.asTableRow().tableRow.cells) {
-                        celList.add(getRichText(richText).replace("  \n", "</br>"))
+                        cellList.add(getRichText(richText).replace("  \n", "</br>"))
                     }
-                    str += "|${celList.joinToString("|")}|\n"
+                    str += "|${cellList.joinToString("|")}|\n"
                 }
             }
         }


### PR DESCRIPTION
Fix: #1 Line breaks in table cells

Replaced line breaks in table cells with `</br>`.